### PR TITLE
Transition from print to logging statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.eggs
+*egg-info

--- a/bacanora/agaveutils/utils.py
+++ b/bacanora/agaveutils/utils.py
@@ -10,6 +10,10 @@ from __future__ import print_function
 import re
 import os
 import time
+
+import logging
+logger = logging.getLogger(__name__)
+
 from agavepy.agave import Agave
 from attrdict import AttrDict
 
@@ -41,11 +45,11 @@ def get_api_server(ag):
         try:
             return ag.token.api_server
         except Exception as e:
-            print("ag.token was None: {}".format(e))
+            logger.error("ag.token was None: {}".format(e))
             pass
         return None
     else:
-        print("Used hard-coded value for API server")
+        logger.info("Used hard-coded value for API server")
         return None
 
 
@@ -57,11 +61,11 @@ def get_api_token(ag):
         try:
             return ag.token.token_info.get('access_token')
         except Exception as e:
-            print("ag.token was None: {}".format(e))
+            logger.error("ag.token was None: {}".format(e))
             pass
         return None
     else:
-        print("Failed to retriev API access_token")
+        logger.error("Failed to retriev API access_token")
         return ""
 
 
@@ -73,8 +77,8 @@ def get_api_username(ag):
         try:
             return ag.username
         except Exception as e:
-            print("ag was None: {}".format(e))
+            logger.error("ag was None: {}".format(e))
         return None
     else:
-        print("No username could be determined")
+        logger.error("No username could be determined")
         return None

--- a/bacanora/bacanora.py
+++ b/bacanora/bacanora.py
@@ -3,13 +3,16 @@ import json
 import re
 import sys
 import tempfile
-from pprint import pprint
+from pprint import pformat
 from attrdict import AttrDict
 from agavepy.agave import AgaveError
 from requests.exceptions import HTTPError
 from tenacity import retry, retry_if_exception_type
 from tenacity import stop_after_delay
 from tenacity import wait_exponential
+
+import logging
+logger = logging.getLogger(__name__)
 
 from . import agaveutils
 from .direct import direct_get, direct_put, DirectOperationFailed
@@ -30,7 +33,7 @@ def download(agave_client, file_to_download, local_filename, system_id='data-sd2
         direct_get(file_to_download, local_filename,
                    system_id='data-sd2e-community')
     except DirectOperationFailed as exc:
-        pprint(exc)
+        logger.info(pformat(exc))
         # Download using Agave API call
         try:
             downloadFileName = os.path.join(PWD, local_filename)
@@ -76,7 +79,7 @@ def upload(agave_client, file_to_upload, destination_path, system_id='data-sd2e-
     try:
         direct_put(file_to_upload, destination_path, system_id='data-sd2e-community')
     except DirectOperationFailed as exc:
-        pprint(exc)
+        logger.info(pformat(exc))
         try:
             agave_client.files.importData(systemId=system_id,
                                           filePath=destination_path,

--- a/bacanora/direct.py
+++ b/bacanora/direct.py
@@ -2,6 +2,9 @@ import os
 import datetime
 import shutil
 
+import logging
+logger = logging.getLogger(__name__)
+
 class DirectOperationFailed(Exception):
     pass
 
@@ -43,7 +46,7 @@ def direct_get(file_to_download, local_filename, system_id='data-sd2e-community'
             file_to_download = file_to_download[1:]
         full_path = os.path.join(prefix, file_to_download)
         temp_local_filename = local_filename + '-' + str(int(datetime.datetime.utcnow().timestamp()))
-        print('DIRECT_GET: {}'.format(full_path))
+        logger.debug('DIRECT_GET: {}'.format(full_path))
         if os.path.exists(full_path):
             shutil.copy(os.path.join(prefix, file_to_download), temp_local_filename)
         else:
@@ -70,7 +73,7 @@ def direct_put(file_to_upload, destination_path, system_id='data-sd2e-community'
         filename_atomic = filename + '-' + str(int(datetime.datetime.utcnow().timestamp()))
         atomic_dest_path = os.path.join(full_dest_path, filename_atomic)
         final_dest_path = os.path.join(full_dest_path, filename)
-        print('DIRECT_PUT: {}'.format(atomic_dest_path))
+        logger.debug('DIRECT_PUT: {}'.format(atomic_dest_path))
         if os.path.exists(full_dest_path):
             shutil.copy(file_to_upload, atomic_dest_path)
         else:

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     long_description_content_type="text/x-rst",
     url="https://github.com/SD2E/bacanora",
     install_requires=get_requirements(),
+    tests_require=get_requirements()+['hashids'],
     dependency_links=get_links(),
     packages=find_packages(),
     license="BSD",


### PR DESCRIPTION
Without debugging a normal download that has to fallback to agave doesn't print anything. When the logger level is set to DEBUG, it prints the following

```
[DEBUG - direct.py:49 -      direct_get] DIRECT_GET: /work/projects/SD2E-Community/prod/data/uploads/ginkgo/201808/Novelchassis-Nand-Gate/74/318/667/6980_analysis.csv
[DEBUG - direct.py:49 -      direct_get] DIRECT_GET: /work/projects/SD2E-Community/prod/data/uploads/ginkgo/201808/Novelchassis-Nand-Gate/74/318/667/6980_analysis.csv
[INFO - bacanora.py:36 -        download] DirectOperationFailed('Failed to download file',)
[INFO - bacanora.py:36 -        download] DirectOperationFailed('Failed to download file',)
[INFO - client.py:64 -        __call__] download?'systemId=data-sd2e-community&filePath=%2Fuploads%2Fginkgo%2F201808%2FNovelchassis-Nand-Gate%2F74%2F318%2F667%2F6980_analysis.csv&proxies=%7B%7D'
[INFO - client.py:172 -        __call__] GET https://api.sd2e.org/files/v2/media/system/data-sd2e-community//uploads/ginkgo/201808/Novelchassis-Nand-Gate/74/318/667/6980_analysis.csv({})
[DEBUG - connectionpool.py:813 -       _new_conn] Starting new HTTPS connection (1): api.sd2e.org:443
[INFO - client.py:64 -        __call__] download?'systemId=data-sd2e-community&filePath=%2Fuploads%2Fginkgo%2F201808%2FNovelchassis-Nand-Gate%2F74%2F318%2F667%2F6980_analysis.csv&proxies=%7B%7D'
[INFO - client.py:172 -        __call__] GET https://api.sd2e.org/files/v2/media/system/data-sd2e-community//uploads/ginkgo/201808/Novelchassis-Nand-Gate/74/318/667/6980_analysis.csv({})
[DEBUG - connectionpool.py:813 -       _new_conn] Starting new HTTPS connection (2): api.sd2e.org:443
[DEBUG - connectionpool.py:393 -   _make_request] https://api.sd2e.org:443 "GET /files/v2/media/system/data-sd2e-community//uploads/ginkgo/201808/Novelchassis-Nand-Gate/74/318/667/6980_analysis.csv HTTP/1.1" 200 17614
[DEBUG - connectionpool.py:393 -   _make_request] https://api.sd2e.org:443 "GET /files/v2/media/system/data-sd2e-community//uploads/ginkgo/201808/Novelchassis-Nand-Gate/74/318/667/6980_analysis.csv HTTP/1.1" 200 17614
```